### PR TITLE
[eslint-plugin-react-hooks] Add option requireUseEffectDependencyArray

### DIFF
--- a/packages/eslint-plugin-react-hooks/README.md
+++ b/packages/eslint-plugin-react-hooks/README.md
@@ -50,6 +50,8 @@ If you want more fine-grained configuration, you can instead add a snippet like 
 
 ## Advanced Configuration
 
+### additionalHooks option
+
 `exhaustive-deps` can be configured to validate dependencies of custom Hooks with the `additionalHooks` option.
 This option accepts a regex to match the names of custom Hooks that have dependencies.
 
@@ -65,6 +67,21 @@ This option accepts a regex to match the names of custom Hooks that have depende
 ```
 
 We suggest to use this option **very sparingly, if at all**. Generally saying, we recommend most custom Hooks to not use the dependencies argument, and instead provide a higher-level API that is more focused around a specific use case.
+
+### requireUseEffectDependencyArray option
+
+`exhaustive-deps` can be configured to disallow calling `useEffect()` without a dependency array. When this option is enabled, to make `useEffect()` re-run on every render you must explicitly pass `undefined` as the second argument. 
+
+```js
+{
+  "rules": {
+    // ...
+    "react-hooks/exhaustive-deps": ["warn", {
+      "requireUseEffectDependencyArray": true
+    }]
+  }
+}
+```
 
 ## Valid and Invalid Examples
 

--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
@@ -1468,6 +1468,26 @@ const tests = {
         }
       `,
     },
+    {
+      code: normalizeIndent`
+        function MyComponent(props) {
+          useEffect(() => {
+            console.log(props.foo);
+          }, undefined);
+        }
+      `,
+      options: [{requireUseEffectDependencyArray: true}],
+    },
+    {
+      code: normalizeIndent`
+        function MyComponent(props) {
+          useEffect(() => {
+            console.log(props.foo);
+          }, [props.foo]);
+        }
+      `,
+      options: [{requireUseEffectDependencyArray: true}],
+    },
   ],
   invalid: [
     {
@@ -7666,6 +7686,42 @@ const tests = {
           message:
             "The 'foo' object makes the dependencies of useEffect Hook (at line 9) change on every render. " +
             "To fix this, wrap the initialization of 'foo' in its own useMemo() Hook.",
+          suggestions: undefined,
+        },
+      ],
+    },
+    {
+      code: normalizeIndent`
+        function MyComponent(props) {
+          useEffect(() => {
+            console.log('banana banana banana');
+          });
+        }
+      `,
+      options: [{requireUseEffectDependencyArray: true}],
+      errors: [
+        {
+          message:
+            'React Hook useEffect will re-run on every render. Did you forget to pass an array of dependencies? ' +
+            "Explicitly pass 'undefined' if this is the intented behaviour.",
+          suggestions: undefined,
+        },
+      ],
+    },
+    {
+      code: normalizeIndent`
+        function MyComponent(props) {
+          useEffect(() => {
+            console.log('banana banana banana');
+          }, testIdentifier);
+        }
+      `,
+      options: [{requireUseEffectDependencyArray: true}],
+      errors: [
+        {
+          message:
+            'React Hook useEffect was passed a dependency list that is not an array literal. ' +
+            "This means we can't statically verify whether you've passed the correct dependencies.",
           suggestions: undefined,
         },
       ],

--- a/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
+++ b/packages/eslint-plugin-react-hooks/__tests__/ESLintRuleExhaustiveDeps-test.js
@@ -1473,16 +1473,6 @@ const tests = {
         function MyComponent(props) {
           useEffect(() => {
             console.log(props.foo);
-          }, undefined);
-        }
-      `,
-      options: [{requireUseEffectDependencyArray: true}],
-    },
-    {
-      code: normalizeIndent`
-        function MyComponent(props) {
-          useEffect(() => {
-            console.log(props.foo);
           }, [props.foo]);
         }
       `,
@@ -7702,8 +7692,24 @@ const tests = {
       errors: [
         {
           message:
-            'React Hook useEffect will re-run on every render. Did you forget to pass an array of dependencies? ' +
-            "Explicitly pass 'undefined' if this is the intented behaviour.",
+            'React Hook useEffect will re-run on every render. Did you forget to pass an array of dependencies? ',
+          suggestions: undefined,
+        },
+      ],
+    },
+    {
+      code: normalizeIndent`
+        function MyComponent(props) {
+          useEffect(() => {
+            console.log(props.foo);
+          }, undefined);
+        }
+      `,
+      options: [{requireUseEffectDependencyArray: true}],
+      errors: [
+        {
+          message:
+            'React Hook useEffect will re-run on every render. Did you forget to pass an array of dependencies? ',
           suggestions: undefined,
         },
       ],

--- a/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
+++ b/packages/eslint-plugin-react-hooks/src/ExhaustiveDeps.js
@@ -1216,8 +1216,6 @@ export default {
         !(maybeNode.type === 'Identifier' && maybeNode.name === 'undefined')
           ? maybeNode
           : undefined;
-      const dependencyNodeIsUndefined =
-        maybeNode && maybeNode.name === 'undefined';
       const isEffect = /Effect($|[^a-z])/g.test(reactiveHookName);
 
       // Check whether a callback is supplied. If there is no callback supplied
@@ -1238,13 +1236,12 @@ export default {
         // If there is no second argument then the reactive callback
         // will re-run on every render. Only need to check if option
         // requireUseEffectDependencyArray is enabled.
-        if (requireUseEffectDependencyArray && !dependencyNodeIsUndefined) {
+        if (requireUseEffectDependencyArray) {
           reportProblem({
             node: reactiveHook,
             message:
               `React Hook ${reactiveHookName} will re-run on every render. ` +
-              `Did you forget to pass an array of dependencies? ` +
-              `Explicitly pass 'undefined' if this is the intented behaviour.`,
+              `Did you forget to pass an array of dependencies? `,
           });
           return;
         }


### PR DESCRIPTION
## New lint option `requireUseEffectDependencyArray`

I propose adding a new option to `react-hooks/exhaustive-deps` lint rule. When specifying `"requireUseEffectDependencyArray": true`, a lint error is raised if the second argument to `useEffect` is omitted. This is intended to prevent accidentally writing effects which re-run on every render. 

![Screenshot 2024-08-08 at 14 53 17](https://github.com/user-attachments/assets/8aaf8e01-e771-4e22-9b3d-e79f2c24ac0d)

## Motivation

Recently I was investigating a spike of logging requests in production at [Faire](https://github.com/Faire) and discovered that the source was inside a `useEffect` which did not have a dependency array. The logging was supposed to happen only once when the component mounts, but instead was sent repeatedly on every render. 

After reviewing a few hundred `useEffect` usages in Faire's repos, I found that this was a frequent mistake. There were a number of other `useEffect` calls that accidentally omitted the dependency array. In our code, it is very rare (only about 1 in 100) that we intentionally want an effect to re-run after every render. Having a lint rule to catch these mistakes will prevent incidents like the traffic spike mentioned above.

## How did you test this change?

 * Added tests and ran `yarn test ESLintRuleExhaustiveDeps`
 * Installed `eslint-plugin-react-hooks` locally and tested with internal Faire repos. 
